### PR TITLE
Add serde support for commonly used types in tcads-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
 name = "js-sys"
 version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +137,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mio"
@@ -219,6 +231,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +295,7 @@ dependencies = [
  "chrono",
  "encoding_rs",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -545,3 +571,9 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -188,6 +189,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +269,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "encoding_rs",
+ "serde",
  "thiserror",
  "tokio",
  "tokio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tcads-server = { path = "packages/tcads-server" }
 tokio = "1"
 tokio-test = "0.4"
 thiserror = "2"
-serde = { version = "1"}
+serde = "1"
+serde_json = "1"
 encoding_rs = "0.8"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ tcads-server = { path = "packages/tcads-server" }
 tokio = "1"
 tokio-test = "0.4"
 thiserror = "2"
+serde = { version = "1"}
 encoding_rs = "0.8"
 chrono = "0.4"

--- a/packages/tcads-core/Cargo.toml
+++ b/packages/tcads-core/Cargo.toml
@@ -10,9 +10,13 @@ keywords = ["twincat", "beckhoff", "ads"]
 categories = ["api-bindings", "network-programming"]
 readme = "README.md"
 
+[features]
+serde = ["dep:serde", "chrono/serde"]
+
 [dependencies]
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "net", "macros"] }
 tokio-test = { workspace = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 encoding_rs = { workspace = true }
 chrono = { workspace = true }

--- a/packages/tcads-core/Cargo.toml
+++ b/packages/tcads-core/Cargo.toml
@@ -20,3 +20,6 @@ tokio-test = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 encoding_rs = { workspace = true }
 chrono = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/packages/tcads-core/src/ads/device_state.rs
+++ b/packages/tcads-core/src/ads/device_state.rs
@@ -17,30 +17,29 @@ pub type DeviceState = u16;
 /// Describes the current operating state (e.g. Run, Stop, Config).
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(u16)] // Wire format is 2 bytes
 pub enum AdsState {
-    Invalid = 0,
-    Idle = 1,
-    Reset = 2,
-    Init = 3,
-    Start = 4,
-    Run = 5,
-    Stop = 6,
-    SaveCfg = 7,
-    LoadCfg = 8,
-    PowerFailure = 9,
-    PowerGood = 10,
-    Error = 11,
-    Shutdown = 12,
-    Suspend = 13,
-    Resume = 14,
-    Config = 15,
-    Reconfig = 16,
-    Stopping = 17,
+    Invalid,
+    Idle,
+    Reset,
+    Init,
+    Start,
+    Run,
+    Stop,
+    SaveCfg,
+    LoadCfg,
+    PowerFailure,
+    PowerGood,
+    Error,
+    Shutdown,
+    Suspend,
+    Resume,
+    Config,
+    Reconfig,
+    Stopping,
     /// System is incompatible.
-    Incompatible = 18,
+    Incompatible,
     /// System Exception.
-    Exception = 19,
+    Exception,
     /// A state not defined in the library.
     Unknown(u16),
 }
@@ -173,5 +172,13 @@ mod tests {
     #[test]
     fn test_ads_state_try_from_slice() {
         assert_eq!(AdsState::try_from_slice(&[1, 0]).unwrap(), AdsState::Idle);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_ads_state_roundtrip() {
+        let state = AdsState::Run;
+        let bytes = serde_json::to_string(&state).unwrap();
+        assert_eq!(state, serde_json::from_str(&bytes).unwrap());
     }
 }

--- a/packages/tcads-core/src/ads/device_state.rs
+++ b/packages/tcads-core/src/ads/device_state.rs
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn test_serde_ads_state_roundtrip() {
         let state = AdsState::Run;
-        let bytes = serde_json::to_string(&state).unwrap();
-        assert_eq!(state, serde_json::from_str(&bytes).unwrap());
+        let s = serde_json::to_string(&state).unwrap();
+        assert_eq!(state, serde_json::from_str(&s).unwrap());
     }
 }

--- a/packages/tcads-core/src/ads/device_state.rs
+++ b/packages/tcads-core/src/ads/device_state.rs
@@ -15,6 +15,7 @@ pub type DeviceState = u16;
 /// The ADS State of the device.
 ///
 /// Describes the current operating state (e.g. Run, Stop, Config).
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u16)] // Wire format is 2 bytes
 pub enum AdsState {

--- a/packages/tcads-core/src/ads/filetime.rs
+++ b/packages/tcads-core/src/ads/filetime.rs
@@ -315,4 +315,24 @@ mod tests {
         let ft = WindowsFileTime::from_raw(KNOWN_TICKS + 5_000_000);
         assert_eq!(format!("{ft}"), "2026-02-21 12:00:00.500000 UTC");
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_windows_file_time_serialize_is_iso8601() {
+        let ft = WindowsFileTime::from_raw(134_161_488_000_000_000); // 2026-02-21 12:00:00 UTC
+        let s = serde_json::to_string(&ft).unwrap();
+        // chrono emits RFC 3339, verify it contains the expected datetime
+        assert!(s.contains("2026-02-21"));
+        assert!(s.contains("12:00:00"));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_windows_file_time_roundtrip() {
+        // Use microsecond-aligned ticks to avoid sub-microsecond precision loss
+        let original = WindowsFileTime::from_raw(134_161_488_000_000_000);
+        let s = serde_json::to_string(&original).unwrap();
+        let back: WindowsFileTime = serde_json::from_str(&s).unwrap();
+        assert_eq!(original, back);
+    }
 }

--- a/packages/tcads-core/src/ads/filetime.rs
+++ b/packages/tcads-core/src/ads/filetime.rs
@@ -159,6 +159,22 @@ impl std::fmt::Display for WindowsFileTime {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for WindowsFileTime {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.to_datetime().serialize(s)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for WindowsFileTime {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Ok(WindowsFileTime::from_datetime(
+            DateTime::<Utc>::deserialize(d)?,
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/tcads-core/src/ads/notification_handle.rs
+++ b/packages/tcads-core/src/ads/notification_handle.rs
@@ -94,6 +94,20 @@ impl fmt::Debug for NotificationHandle {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for NotificationHandle {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_u32(self.as_u32())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for NotificationHandle {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Ok(NotificationHandle::from(u32::deserialize(d)?))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/tcads-core/src/ads/notification_handle.rs
+++ b/packages/tcads-core/src/ads/notification_handle.rs
@@ -175,4 +175,28 @@ mod tests {
         assert_eq!(map[&h2], "handler_a");
         assert!(!map.contains_key(&h3));
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_notification_handle_serialize() {
+        let handle = NotificationHandle::from(42_u32);
+        let s = serde_json::to_string(&handle).unwrap();
+        assert_eq!(s, "42");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_notification_handle_deserialize() {
+        let handle: NotificationHandle = serde_json::from_str("42").unwrap();
+        assert_eq!(handle, NotificationHandle::from(42_u32));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_notification_handle_roundtrip() {
+        let original = NotificationHandle::from(0x0000_001A_u32);
+        let s = serde_json::to_string(&original).unwrap();
+        let back: NotificationHandle = serde_json::from_str(&s).unwrap();
+        assert_eq!(original, back);
+    }
 }

--- a/packages/tcads-core/src/ads/return_codes.rs
+++ b/packages/tcads-core/src/ads/return_codes.rs
@@ -4,6 +4,7 @@ use super::error::AdsReturnCodeError;
 ///
 /// See [Beckhoff ADS Specification (TE1000)](https://infosys.beckhoff.com/content/1033/tc3_ads_intro/374277003.html?id=4954945278371876402)
 /// for reference
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AdsReturnCode {
     #[error("No Error (0x00)")]

--- a/packages/tcads-core/src/ads/return_codes.rs
+++ b/packages/tcads-core/src/ads/return_codes.rs
@@ -743,4 +743,13 @@ mod tests {
         let bytes: [u8; AdsReturnCode::LENGTH] = AdsReturnCode::RtErrIrqlNotLessOrEqual.into();
         assert_eq!([0x10, 0x10, 0x00, 0x00], bytes);
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_ads_return_code_roundtrip() {
+        let code = AdsReturnCode::Ok;
+        let s = serde_json::to_string(&code).unwrap();
+        let back: AdsReturnCode = serde_json::from_str(&s).unwrap();
+        assert_eq!(code, back);
+    }
 }

--- a/packages/tcads-core/src/ads/trans_mode.rs
+++ b/packages/tcads-core/src/ads/trans_mode.rs
@@ -3,6 +3,7 @@ use super::error::AdsTransModeError;
 /// The transition mode for Device Notifications.
 ///
 /// Determines when the server sends a notification to the client.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u32)] // Wire format is 4 bytes
 pub enum AdsTransMode {

--- a/packages/tcads-core/src/ads/trans_mode.rs
+++ b/packages/tcads-core/src/ads/trans_mode.rs
@@ -125,4 +125,12 @@ mod tests {
             AdsTransMode::ClientOnChange
         );
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_trans_mode_roundtrip() {
+        let mode = AdsTransMode::ClientCycle;
+        let s = serde_json::to_string(&mode).unwrap();
+        assert_eq!(mode, serde_json::from_str(&s).unwrap());
+    }
 }

--- a/packages/tcads-core/src/ads/trans_mode.rs
+++ b/packages/tcads-core/src/ads/trans_mode.rs
@@ -5,18 +5,17 @@ use super::error::AdsTransModeError;
 /// Determines when the server sends a notification to the client.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(u32)] // Wire format is 4 bytes
 pub enum AdsTransMode {
     /// No transmission.
-    None = 0,
+    None,
     /// Cyclic transmission. The server checks the variable cyclically.
-    ClientCycle = 1,
+    ClientCycle,
     /// Transmission on change. The server checks the variable cyclically and sends only if it changed.
-    ClientOnChange = 2,
+    ClientOnChange,
     /// Cyclic transmission (Server-driven). (Not commonly used by clients).
-    ServerCycle = 3,
+    ServerCycle,
     /// Transmission on change (Server-driven). (Not commonly used by clients).
-    ServerOnChange = 4,
+    ServerOnChange,
     /// Unknown/Custom mode.
     Unknown(u32),
 }
@@ -99,10 +98,23 @@ mod tests {
 
     #[test]
     fn test_ads_trans_mode_conversion() {
+        assert_eq!(AdsTransMode::from(0), AdsTransMode::None);
+        assert_eq!(u32::from(AdsTransMode::None), 0);
+
         assert_eq!(AdsTransMode::from(1), AdsTransMode::ClientCycle);
         assert_eq!(u32::from(AdsTransMode::ClientCycle), 1);
 
+        assert_eq!(AdsTransMode::from(2), AdsTransMode::ClientOnChange);
+        assert_eq!(u32::from(AdsTransMode::ClientOnChange), 2);
+
+        assert_eq!(AdsTransMode::from(3), AdsTransMode::ServerCycle);
+        assert_eq!(u32::from(AdsTransMode::ServerCycle), 3);
+
+        assert_eq!(AdsTransMode::from(4), AdsTransMode::ServerOnChange);
+        assert_eq!(u32::from(AdsTransMode::ServerOnChange), 4);
+
         assert_eq!(AdsTransMode::from(100), AdsTransMode::Unknown(100));
+        assert_eq!(u32::from(AdsTransMode::Unknown(100)), 100);
     }
 
     #[test]

--- a/packages/tcads-core/src/ams/addr.rs
+++ b/packages/tcads-core/src/ams/addr.rs
@@ -181,4 +181,28 @@ mod tests {
         let addr: AmsAddr = original.parse().unwrap();
         assert_eq!(addr.to_string(), original);
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_ams_addr_serialize() {
+        let addr = AmsAddr::new(AmsNetId::new(192, 168, 0, 1, 1, 1), 851);
+        let s = serde_json::to_string(&addr).unwrap();
+        assert_eq!(s, r#""192.168.0.1.1.1:851""#);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_ams_addr_deserialize() {
+        let addr: AmsAddr = serde_json::from_str(r#""192.168.0.1.1.1:851""#).unwrap();
+        assert_eq!(addr, AmsAddr::new(AmsNetId::new(192, 168, 0, 1, 1, 1), 851));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_ams_addr_roundtrip() {
+        let original = AmsAddr::new(AmsNetId::new(172, 16, 0, 1, 1, 1), 30000);
+        let s = serde_json::to_string(&original).unwrap();
+        let roundtripped: AmsAddr = serde_json::from_str(&s).unwrap();
+        assert_eq!(original, roundtripped);
+    }
 }

--- a/packages/tcads-core/src/ams/addr.rs
+++ b/packages/tcads-core/src/ams/addr.rs
@@ -122,6 +122,21 @@ impl fmt::Display for AmsAddr {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for AmsAddr {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for AmsAddr {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = <&str>::deserialize(d)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/tcads-core/src/ams/net_id.rs
+++ b/packages/tcads-core/src/ams/net_id.rs
@@ -123,6 +123,21 @@ impl fmt::Debug for AmsNetId {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for AmsNetId {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for AmsNetId {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = <&str>::deserialize(d)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/tcads-core/src/ams/net_id.rs
+++ b/packages/tcads-core/src/ams/net_id.rs
@@ -173,4 +173,35 @@ mod tests {
         let err = AmsNetId::try_from(&bytes[..]).unwrap_err();
         assert!(matches!(err, NetIdError::InvalidBufferSize { .. }));
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_ams_net_id_serialize() {
+        let id = AmsNetId::new(192, 168, 0, 1, 1, 1);
+        let s = serde_json::to_string(&id).unwrap();
+        assert_eq!(s, r#""192.168.0.1.1.1""#);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_ams_net_id_deserialize() {
+        let id: AmsNetId = serde_json::from_str(r#""192.168.0.1.1.1""#).unwrap();
+        assert_eq!(id, AmsNetId::new(192, 168, 0, 1, 1, 1));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_ams_net_id_roundtrip() {
+        let original = AmsNetId::new(10, 0, 0, 1, 1, 1);
+        let s = serde_json::to_string(&original).unwrap();
+        let roundtripped: AmsNetId = serde_json::from_str(&s).unwrap();
+        assert_eq!(original, roundtripped);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_ams_net_id_invalid_string() {
+        let err = serde_json::from_str::<AmsNetId>(r#""not.a.valid.netid""#);
+        assert!(err.is_err());
+    }
 }

--- a/packages/tcads-core/src/io/frame.rs
+++ b/packages/tcads-core/src/io/frame.rs
@@ -170,7 +170,7 @@ mod tests {
 
         assert_eq!(frame.header().command(), AmsCommand::GetLocalNetId);
         assert_eq!(frame.header().length(), 0);
-        assert_eq!(frame.payload(), &[]);
+        assert_eq!(frame.payload(), &[] as &[u8]);
     }
 
     #[test]


### PR DESCRIPTION
### Summary

Adds optional serde serialization and deserialization support to the types users are most likely to store in config files, logs, or persistent state. Feature-gated behind serde so there is no compile-time cost for those who don't need it.