### PR TITLE
Add tokio TwinCAT Logger ADS device

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,10 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="DuplicatedCode" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <Languages>
+        <language minSize="88" name="Rust" />
+      </Languages>
+    </inspection_tool>
+  </profile>
+</component>

--- a/examples/src/bin/11_async_system_logger.rs
+++ b/examples/src/bin/11_async_system_logger.rs
@@ -1,0 +1,91 @@
+//! Example 11: Async TwinCAT System Logger
+//! Run with: `cargo run --bin 11_async_system_logger`
+//!
+//! Demonstrates how to share a single AMS connection between an async `Logger`
+//! (for subscribing and writing) and a background listener task, using Tokio.
+//!
+//! This sits between examples 9 and 10 in complexity: like example 9 it uses
+//! only the Logger API without touching PLC symbol handles, but like example 10
+//! it shares a connection and runs concurrent tasks.
+
+use std::time::Duration;
+use tcads::client::devices::tokio::{Logger, MessageType};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("Connecting to the TwinCAT System Logger...");
+
+    // 1. Connect directly to the logger.
+    // This handles the PortConnect handshake and targets Port 100 automatically.
+    let logger = Logger::connect(Duration::from_secs(5)).await?;
+
+    // 2. Subscribe to the logger notification stream.
+    // Clone the logger so the listener task and the main task share the same
+    // connection without opening a second socket.
+    let (mut rx, handle) = logger.subscribe().await?;
+    let logger_clone = logger.clone();
+    println!("Subscribed to Logger Notifications!");
+
+    // 3. Spawn a background task to print incoming log entries.
+    // The task owns `rx` and stops itself after receiving our marker message.
+    let listener = tokio::spawn(async move {
+        println!("\nWaiting for logs to arrive...");
+        println!("---------------------------------------------------");
+
+        while let Ok(entry) = rx.recv().await {
+            println!(
+                "{}\t{} | '{}' ({}): {}",
+                entry.message_type(),
+                entry.timestamp(),
+                entry.sender(),
+                entry.sender_port(),
+                entry.message()
+            );
+
+            if entry.message().contains("Goodbye") {
+                println!("---------------------------------------------------");
+                println!("Goodbye message received. Listener exiting.");
+                logger_clone.unsubscribe(handle).await.unwrap();
+            }
+        }
+    });
+
+    // 4. Write a few messages while the listener runs concurrently.
+    // We can combine MessageTypes using the standard bitwise OR operator.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    println!("Writing messages to the logger...");
+
+    logger
+        .write_log(
+            MessageType::new(MessageType::HINT | MessageType::LOG),
+            "RustClient",
+            "Hint from tcads-rs.",
+        )
+        .await?;
+
+    logger
+        .write_log(
+            MessageType::new(MessageType::WARNING | MessageType::LOG),
+            "RustClient",
+            "Warning from tcads-rs.",
+        )
+        .await?;
+
+    // The listener stops when it sees this message.
+    logger
+        .write_log(
+            MessageType::new(MessageType::ERROR | MessageType::LOG),
+            "RustClient",
+            "Goodbye from tcads-rs!",
+        )
+        .await?;
+
+    // 5. Wait for the listener to finish, then clean up.
+    listener.await?;
+
+    println!("Done.");
+    Ok(())
+}

--- a/packages/tcads-client/src/devices/ads_device/tokio.rs
+++ b/packages/tcads-client/src/devices/ads_device/tokio.rs
@@ -17,8 +17,9 @@ use tcads_core::protocol::{
     GetLocalNetIdResponse, PortCloseRequest, PortConnectRequest, PortConnectResponse,
 };
 use tcads_core::{
-    AdsDeviceVersion, AdsReturnCode, AdsState, AdsTransMode, AmsAddr, AmsFrame, AmsNetId,
-    DeviceState, IndexGroup, IndexOffset, InvokeId, NotificationHandle, RouterState,
+    AdsDeviceVersion, AdsHeader, AdsReturnCode, AdsState, AdsTransMode, AmsAddr, AmsCommand,
+    AmsFrame, AmsNetId, DeviceState, IndexGroup, IndexOffset, InvokeId, NotificationHandle,
+    RouterState,
 };
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::RwLock;
@@ -566,6 +567,72 @@ impl AdsDevice {
         Self::check_result(resp.result())?;
         self.inner.ads_notifs.remove(handle).await;
         Ok(())
+    }
+    /// Sends a fire-and-forget frame to the router.
+    ///
+    /// This method exists for unconventional ADS commands that do not follow the
+    /// standard request/response pattern, such as
+    /// [`AdsDeviceNotification`](tcads_core::AdsCommand::AdsDeviceNotification) frames
+    /// written directly to the TwinCAT logger (port 100). For standard commands
+    /// that expect a response, use the high-level methods on [`AdsDevice`].
+    ///
+    /// # Warning
+    ///
+    /// The frame is queued on the writer channel and sent as-is. No `InvokeId`
+    /// is registered with the dispatcher, so **any reply the router sends will be
+    /// silently dropped**.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the [`AmsFrame`] is correctly formed for the intended
+    /// unconventional command. An incorrect frame such as; a malformed ADS header,
+    /// wrong target address, or an invalid payload layout, can cause undefined
+    /// behaviour in the remote TwinCAT runtime. This including crashes, silent data
+    /// corruption, or unexpected state transitions that affect the entire PLC task
+    pub unsafe fn write_frame_only(&self, frame: AmsFrame) -> crate::Result<()> {
+        self.inner.ams_requests.send_only(frame)
+    }
+
+    /// Sends a frame and returns a [`Receiver`] for the matching response.
+    ///
+    /// This method exists for unconventional ADS commands that are not covered by
+    /// the high-level API on [`AdsDevice`]. For standard commands, prefer the
+    /// typed methods (e.g. [`read`](Self::read), [`write`](Self::write)) which
+    /// handle `InvokeId` assignment, frame construction, and response parsing.
+    /// For unconventional commands that never receive a response, use
+    /// [`write_frame_only`](Self::write_frame_only) instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err(Error::InvalidPayload)`](crate::Error::InvalidPayload) if the
+    /// frame carries an [`AmsCommand`] variant that has no dispatch key (anything
+    /// other than [`AdsCommand`](AmsCommand::AdsCommand), [`GetLocalNetId`](AmsCommand::GetLocalNetId),
+    /// or [`PortConnect`](AmsCommand::PortConnect)).
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the [`AmsFrame`] is correctly formed for the intended
+    /// unconventional command. An incorrect frame such as; a malformed ADS header,
+    /// wrong target address, or an invalid payload layout, can cause undefined
+    /// behaviour in the remote TwinCAT runtime. This including crashes, silent data
+    /// corruption, or unexpected state transitions that affect the entire PLC task.
+    ///
+    /// The caller is also responsible for ensuring the `InvokeId` embedded in the
+    /// [`AdsHeader`] is unique among all in-flight requests on this connection.
+    /// A duplicate `InvokeId` will cause the wrong caller to receive the response.
+    pub async unsafe fn write_frame(&self, frame: AmsFrame) -> crate::Result<Receiver<AmsFrame>> {
+        let key = match frame.header().command() {
+            AmsCommand::AdsCommand => {
+                let (header, _) =
+                    AdsHeader::parse_prefix(frame.payload()).map_err(tcads_core::AdsError::from)?;
+                AmsRequestDispatchKey::AdsCommand(header.invoke_id())
+            }
+            AmsCommand::GetLocalNetId => AmsRequestDispatchKey::GetLocalNetId,
+            AmsCommand::PortConnect => AmsRequestDispatchKey::PortConnect,
+            _ => return Err(crate::Error::InvalidPayload),
+        };
+
+        self.inner.ams_requests.dispatch(key, frame).await
     }
 
     async fn send_and_wait(&self, frame: AmsFrame, invoke_id: InvokeId) -> crate::Result<AmsFrame> {

--- a/packages/tcads-client/src/devices/logger/blocking.rs
+++ b/packages/tcads-client/src/devices/logger/blocking.rs
@@ -233,6 +233,7 @@ pub struct LogEntryReceiver {
 }
 
 impl LogEntryReceiver {
+    /// Creates a new instance of the [`LogEntryReceiver`].
     pub fn new(
         rx: Receiver<AdsNotificationSampleOwned>,
         guard: NotificationGuard,

--- a/packages/tcads-client/src/devices/logger/blocking.rs
+++ b/packages/tcads-client/src/devices/logger/blocking.rs
@@ -174,8 +174,7 @@ impl Logger {
     /// The subscription is cancelled automatically when the [`LogEntryReceiver`]
     /// is dropped, or explicitly via [`unsubscribe`](Self::unsubscribe).
     ///
-    /// Multiple subscriptions can be active simultaneously, and each returns an
-    /// independent [`LogEntryReceiver`].
+    /// Multiple subscriptions can be active simultaneously.
     pub fn subscribe(&self) -> crate::Result<(LogEntryReceiver, NotificationHandle)> {
         let (rx, handle) = self.inner.device.add_notification(
             self.inner.target,

--- a/packages/tcads-client/src/devices/logger/blocking.rs
+++ b/packages/tcads-client/src/devices/logger/blocking.rs
@@ -1,8 +1,8 @@
+use super::log_entry::entry_to_frame;
 use super::{
     LOGGER_DATA_LEN, LOGGER_INDEX_GROUP, LOGGER_INDEX_OFFSET, LOGGER_PORT, LogEntry, MessageType,
 };
 use crate::devices::blocking::AdsDevice;
-use crate::devices::logger::log_entry::entry_to_frame;
 use crate::notif_guard::blocking::NotificationGuard;
 use std::collections::HashSet;
 use std::net::ToSocketAddrs;

--- a/packages/tcads-client/src/devices/logger/mod.rs
+++ b/packages/tcads-client/src/devices/logger/mod.rs
@@ -1,6 +1,7 @@
 pub mod blocking;
 pub mod log_entry;
 pub mod message_type;
+pub mod tokio;
 
 pub use log_entry::LogEntry;
 pub use message_type::MessageType;

--- a/packages/tcads-client/src/devices/logger/tokio.rs
+++ b/packages/tcads-client/src/devices/logger/tokio.rs
@@ -1,0 +1,314 @@
+use super::log_entry::entry_to_frame;
+use super::{
+    LOGGER_DATA_LEN, LOGGER_INDEX_GROUP, LOGGER_INDEX_OFFSET, LOGGER_PORT, LogEntry, MessageType,
+};
+use crate::devices::tokio::AdsDevice;
+use crate::notif_guard::tokio::NotificationGuard;
+use std::collections::HashSet;
+use std::net::ToSocketAddrs;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tcads_core::{
+    AdsNotificationSampleOwned, AdsTransMode, AmsAddr, AmsNetId, NotificationHandle,
+    WindowsFileTime,
+};
+use tokio::sync::mpsc::UnboundedReceiver as Receiver;
+use tokio::sync::mpsc::error::TryRecvError;
+
+/// Shared state of an async [`AdsDevice`] client for the TwinCAT system logger.
+///
+/// Held behind an [`Arc`] so all [`Logger`] clones share the same connection.
+/// Exposed as `pub` for power users who need direct access to the underlying
+/// dispatchers to build custom device abstractions on top of the
+/// same connection without going through the [`Logger`] API.
+///
+/// # Lifetime
+///
+/// All [`LogEntryReceiver`]s hold an [`Arc`] clone of this inner state.
+/// The underlying connection and handle tracking remain alive as long as
+/// either a [`Logger`] clone or a [`LogEntryReceiver`] exists.
+/// When the last reference is dropped, [`Drop`] fires and all active
+/// notification handles are deleted from the router.
+pub struct LoggerInner {
+    pub device: AdsDevice,
+    pub target: AmsAddr,
+    pub handles: Mutex<HashSet<NotificationHandle>>,
+}
+
+impl Drop for LoggerInner {
+    fn drop(&mut self) {
+        let Ok(mut handles) = self.handles.lock() else {
+            return;
+        };
+
+        if handles.is_empty() {
+            return;
+        }
+
+        let device = self.device.clone();
+        let target = self.target;
+        let handles_to_delete: Vec<_> = handles.drain().collect();
+
+        // Safely check for a Tokio runtime context before spawning the clean-up task
+        if let Ok(rt) = tokio::runtime::Handle::try_current() {
+            rt.spawn(async move {
+                for handle in handles_to_delete {
+                    let _ = device.delete_notification(target, handle).await;
+                }
+            });
+        }
+        // No runtime context, this is best-effort at best, router cleans up on connection close
+        // anyway. 100% safe to ignore.
+    }
+}
+
+/// An asynchronous [`AdsDevice`] client for the TwinCAT system logger on ADS port `100`.
+///
+/// # Thread Safety
+///
+/// `Logger` is [`Clone`], so all clones share the same underlying connection.
+/// It is also [`Send`] + [`Sync`], so multiple tasks can write or receive log
+/// entries concurrently. Clean-up only happens when the last clone is dropped.
+#[derive(Clone)]
+pub struct Logger {
+    inner: Arc<LoggerInner>,
+}
+
+impl Logger {
+    /// Connects to the local AMS router at `127.0.0.1:48898`.
+    ///
+    /// # Note
+    ///
+    /// On Windows, connecting via `127.0.0.1` requires the
+    /// `EnableAmsTcpLoopback` registry key to be set. This is enabled by
+    /// default in TwinCAT 4024.5 and newer.
+    pub async fn connect(timeout: impl Into<Option<Duration>>) -> crate::Result<Self> {
+        Self::connect_to("127.0.0.1:48898", timeout).await
+    }
+
+    /// Connects to an AMS router at `addr`.
+    ///
+    /// Performs a [`PortConnect`](tcads_core::protocol::PortConnectRequest) handshake
+    /// to obtain a dynamically assigned source address.
+    pub async fn connect_to(
+        addr: impl ToSocketAddrs,
+        timeout: impl Into<Option<Duration>>,
+    ) -> crate::Result<Self> {
+        let device = AdsDevice::connect_to(addr, timeout).await?;
+        let net_id = device.get_local_net_id().await?;
+        Ok(Self::new(device, net_id))
+    }
+
+    /// Connects directly to a remote AMS router without a local router.
+    ///
+    /// The `source` address must be pre-configured as a static route on the
+    /// remote router. The `net_id` should be the Net ID of the remote router
+    /// and is used to address the logger target (`net_id:100`).
+    ///
+    /// The [`PortConnect`](tcads_core::protocol::PortConnectRequest) handshake
+    /// is **not** performed. See [`AdsDevice::connect_remote`] for details.
+    pub async fn connect_remote(
+        addr: impl ToSocketAddrs,
+        source: AmsAddr,
+        net_id: AmsNetId,
+        timeout: impl Into<Option<Duration>>,
+    ) -> crate::Result<Self> {
+        let device = AdsDevice::connect_remote(addr, source, timeout).await?;
+        Ok(Self::new(device, net_id))
+    }
+
+    /// Creates a `Logger` from an existing [`AdsDevice`] and router Net ID.
+    ///
+    /// Use this when sharing an existing connection with other device clients.
+    /// `net_id` is used to construct the logger target address (`net_id:100`).
+    pub fn new(device: AdsDevice, net_id: AmsNetId) -> Self {
+        Self {
+            inner: Arc::new(LoggerInner {
+                device,
+                target: AmsAddr::new(net_id, LOGGER_PORT),
+                handles: Mutex::new(HashSet::new()),
+            }),
+        }
+    }
+
+    /// Shuts down the underlying connection.
+    ///
+    /// See [`AdsDevice::shutdown`] for more details.
+    pub async fn shutdown(&self) {
+        self.inner.device.shutdown().await
+    }
+
+    /// Returns the target address of the logger.
+    pub fn target(&self) -> AmsAddr {
+        self.inner.target
+    }
+
+    /// Returns a reference to the underlying [`AdsDevice`].
+    pub fn get_ref(&self) -> &AdsDevice {
+        &self.inner.device
+    }
+
+    /// Writes a log message to the TwinCAT logger using the current system time.
+    ///
+    /// `task_name` is encoded as Windows-1252 and truncated to
+    /// [`MAX_TASK_NAME_LEN`](super::MAX_TASK_NAME_LEN) - 1 characters if it exceeds
+    /// that limit.
+    pub async fn write_log<A: AsRef<str>>(
+        &self,
+        message_type: MessageType,
+        task_name: A,
+        message: A,
+    ) -> crate::Result<()> {
+        self.write_entry(LogEntry::new(
+            WindowsFileTime::now(),
+            message_type,
+            self.get_ref().source().await.port(),
+            task_name.as_ref().to_owned(),
+            message.as_ref().to_owned(),
+        ))
+        .await
+    }
+
+    /// Writes a [`LogEntry`] to the TwinCAT logger.
+    ///
+    /// This replicates [`ADSLOGSTR`](https://infosys.beckhoff.com/content/1033/tcplclib_tc2_system/31033611.html)
+    /// from Structured Text, sending an ADS Device Notification directly to port 100.
+    ///
+    /// Prefer [`write_log`](Self::write_log) for most use cases. Use this method
+    /// when you need full control over the [`LogEntry`], such as providing an explicit
+    /// timestamp via [`LogEntry::new`].
+    ///
+    /// `entry.sender` is encoded as Windows-1252 and truncated to
+    /// [`MAX_TASK_NAME_LEN`](super::MAX_TASK_NAME_LEN) - 1 characters if it exceeds
+    /// that limit.
+    pub async fn write_entry(&self, entry: LogEntry) -> crate::Result<()> {
+        let frame = entry_to_frame(self.target(), self.get_ref().source().await, entry);
+        unsafe { self.get_ref().write_frame_only(frame) }
+    }
+
+    /// Subscribes asynchronously to TwinCAT logger notifications.
+    ///
+    /// Returns a [`LogEntryReceiver`] that yields decoded [`LogEntry`] values.
+    /// The subscription is cancelled automatically when the [`LogEntryReceiver`] is dropped.
+    ///
+    /// Multiple subscriptions can be active simultaneously.
+    pub async fn subscribe(&self) -> crate::Result<(LogEntryReceiver, NotificationHandle)> {
+        let (rx, handle) = self
+            .inner
+            .device
+            .add_notification(
+                self.inner.target,
+                LOGGER_INDEX_GROUP,
+                LOGGER_INDEX_OFFSET,
+                LOGGER_DATA_LEN,
+                AdsTransMode::ServerCycle,
+                0,
+                0,
+            )
+            .await?;
+
+        match self.inner.handles.lock() {
+            Ok(mut handles) => {
+                handles.insert(handle);
+            }
+            Err(e) => {
+                let _ = self
+                    .inner
+                    .device
+                    .delete_notification(self.inner.target, handle)
+                    .await;
+                return Err(e.into());
+            }
+        };
+
+        let guard = NotificationGuard::new(handle, self.inner.target, self.inner.device.clone());
+
+        Ok((
+            LogEntryReceiver::new(rx, guard, Arc::clone(&self.inner)),
+            handle,
+        ))
+    }
+
+    /// Explicitly cancels a subscription by its handle.
+    ///
+    /// The [`LogEntryReceiver`] associated with this handle will return
+    /// [`Err(Error::Disconnected)`](crate::Error::Disconnected) on its next call.
+    ///
+    /// Dropping the [`LogEntryReceiver`] has the same effect and is preferred
+    /// in most cases.
+    pub async fn unsubscribe(&self, handle: NotificationHandle) -> crate::Result<()> {
+        if let Ok(mut handles) = self.inner.handles.lock() {
+            handles.remove(&handle);
+        }
+        self.inner
+            .device
+            .delete_notification(self.inner.target, handle)
+            .await
+    }
+}
+
+/// An asynchronous receiver for decoded [`LogEntry`] values.
+///
+/// Wraps the raw ADS notification channel and decodes each sample on demand.
+/// The subscription is cancelled automatically when this is dropped.
+///
+/// Obtain one by calling [`Logger::subscribe`].
+pub struct LogEntryReceiver {
+    rx: Receiver<AdsNotificationSampleOwned>,
+    guard: NotificationGuard,
+    inner: Arc<LoggerInner>,
+}
+
+impl LogEntryReceiver {
+    /// Creates a new instance of the [`LogEntryReceiver`].
+    pub fn new(
+        rx: Receiver<AdsNotificationSampleOwned>,
+        guard: NotificationGuard,
+        inner: Arc<LoggerInner>,
+    ) -> Self {
+        Self { rx, guard, inner }
+    }
+
+    /// Returns the notification handle for this subscription.
+    pub fn handle(&self) -> NotificationHandle {
+        self.guard.handle()
+    }
+
+    /// Asynchronously awaits the next log entry.
+    ///
+    /// Returns [`Err(Error::Disconnected)`](crate::Error::Disconnected) when the
+    /// subscription is cancelled or the connection is lost.
+    ///
+    /// # Note
+    ///
+    /// Unlike the blocking [`recv`](super::blocking::LogEntryReceiver::recv), this
+    /// method requires `&mut self` because Tokio's [`Receiver`] does not support
+    /// shared references.
+    pub async fn recv(&mut self) -> crate::Result<LogEntry> {
+        let sample = self.rx.recv().await.ok_or(crate::Error::Disconnected)?;
+        LogEntry::try_from(sample.data())
+    }
+
+    /// Returns the next log entry if one is immediately available, without awaiting.
+    ///
+    /// Returns [`Ok(None)`] if no sample is currently available,
+    /// or [`Err(Error::Disconnected)`](crate::Error::Disconnected) if the
+    /// subscription is cancelled or the connection is lost.
+    pub fn try_recv(&mut self) -> crate::Result<Option<LogEntry>> {
+        match self.rx.try_recv() {
+            Ok(sample) => Ok(Some(LogEntry::try_from(sample.data())?)),
+            Err(TryRecvError::Empty) => Ok(None),
+            Err(TryRecvError::Disconnected) => Err(crate::Error::Disconnected),
+        }
+    }
+}
+
+impl Drop for LogEntryReceiver {
+    fn drop(&mut self) {
+        let _ = self
+            .inner
+            .handles
+            .lock()
+            .map(|mut h| h.remove(&self.guard.handle()));
+    }
+}

--- a/packages/tcads-client/src/devices/mod.rs
+++ b/packages/tcads-client/src/devices/mod.rs
@@ -11,4 +11,8 @@ pub mod blocking {
 
 pub mod tokio {
     pub use super::ads_device::tokio::AdsDevice;
+    pub use super::logger::{
+        LogEntry, MessageType,
+        tokio::{LogEntryReceiver, Logger},
+    };
 }


### PR DESCRIPTION
### Summary

Adds an async `Logger` device to the `tcads-client` crate for interacting with the TwinCAT System Event Logger (Port 100).

```rust
use std::time::Duration;
use tcads::client::devices::tokio::{Logger, MessageType};

type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;

#[tokio::main]
async fn main() -> Result<()> {
    println!("Connecting to the TwinCAT System Logger...");

    // 1. Connect directly to the logger.
    // This handles the PortConnect handshake and targets Port 100 automatically.
    let logger = Logger::connect(Duration::from_secs(5)).await?;

    // 2. Subscribe to the logger notification stream.
    // Clone the logger so the listener task and the main task share the same
    // connection without opening a second socket.
    let (mut rx, handle) = logger.subscribe().await?;
    let logger_clone = logger.clone();
    println!("Subscribed to Logger Notifications!");

    // 3. Spawn a background task to print incoming log entries.
    // The task owns `rx` and stops itself after receiving our marker message.
    let listener = tokio::spawn(async move {
        println!("\nWaiting for logs to arrive...");
        println!("---------------------------------------------------");

        while let Ok(entry) = rx.recv().await {
            println!(
                "{}\t{} | '{}' ({}): {}",
                entry.message_type(),
                entry.timestamp(),
                entry.sender(),
                entry.sender_port(),
                entry.message()
            );

            if entry.message().contains("Goodbye") {
                println!("---------------------------------------------------");
                println!("Goodbye message received. Listener exiting.");
                logger_clone.unsubscribe(handle).await.unwrap();
            }
        }
    });

    // 4. Write a few messages while the listener runs concurrently.
    // We can combine MessageTypes using the standard bitwise OR operator.
    tokio::time::sleep(Duration::from_millis(100)).await;

    println!("Writing messages to the logger...");

    logger
        .write_log(
            MessageType::new(MessageType::HINT | MessageType::LOG),
            "RustClient",
            "Hint from tcads-rs.",
        )
        .await?;

    logger
        .write_log(
            MessageType::new(MessageType::WARNING | MessageType::LOG),
            "RustClient",
            "Warning from tcads-rs.",
        )
        .await?;

    // The listener stops when it sees this message.
    logger
        .write_log(
            MessageType::new(MessageType::ERROR | MessageType::LOG),
            "RustClient",
            "Goodbye from tcads-rs!",
        )
        .await?;

    // 5. Wait for the listener to finish, then clean up.
    listener.await?;

    println!("Done.");
    Ok(())
}
```

### Notes

- The async `Logger` device is `Clone + Send + Sync` allowing it to be used across threads, see `11_async_system_logger.rs` in the `examples/bin` folder.